### PR TITLE
adding openslide-python==1.2.0 dependency for python biding of openslide

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -37,3 +37,4 @@ dependencies:
   - tqdm=4.64.1
   - segmentation-models-pytorch==0.2.1
   - xgboost==1.7.4
+  - openslide-python==1.2.0

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -38,3 +38,4 @@ dependencies:
   - tqdm=4.64.1
   - segmentation-models-pytorch==0.2.1
   - xgboost==1.7.4
+  - openslide-python==1.2.0


### PR DESCRIPTION
Openslide is already installed in the environment but not its python binding which makes it unusable in python language.