### PR TITLE
Asap add

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -37,8 +37,8 @@ RUN echo "Installing base packages..." \
     && apt-get install -y apt-utils 2> /dev/null \
     && xargs -a /home/${RUNTIME_USER}/apt.txt apt-get install -y \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /home/${RUNTIME_USER}/apt.txt
-
+    && rm -f /home/${RUNTIME_USER}/apt.txt
+	#rm -rf /var/lib/apt/lists/*
 # ======================== user ========================
 USER ${RUNTIME_USER}
 
@@ -63,6 +63,29 @@ RUN [ ${CPU_OR_GPU} = "gpu" ] && export CONDA_OVERRIDE_CUDA="11.0" || export CON
     && find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete \
     && find ${CONDA_DIR} -follow -type f -name '*.js.map' -delete
 
+USER root
+
+ENV BASE_INSTALL=pkgs
+#COPY $BASE_INSTALL/ /$BASE_INSTALL
+RUN mkdir /$BASE_INSTALL \
+    && wget -P /$BASE_INSTALL https://github.com/computationalpathologygroup/ASAP/releases/download/ASAP-2.1/ASAP-2.1-py310-Ubuntu2004.deb
+# Install ASAP
+RUN apt-get update \
+    && seq 3 | xargs -i apt install -y libboost-program-options1.71.0 libboost-regex1.71.0 libdcmtk14 \
+    && dpkg --install /$BASE_INSTALL/ASAP-2.1-py310-Ubuntu2004.deb || true \
+    && apt-get -f install --fix-missing --fix-broken --assume-yes \
+    && dpkg -i /$BASE_INSTALL/ASAP-2.1-py310-Ubuntu2004.deb \
+    && ldconfig -v \
+    && apt-get clean \
+    && echo "/opt/ASAP/bin" > ${CONDA_DIR}/envs/${CONDA_ENV}/lib/python3.10/site-packages/asap.pth \
+    && :
+
+RUN rm -rf /$BASE_INSTALL
+RUN rm /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+RUN ln -s ${CONDA_DIR}/envs/${CONDA_ENV}/lib/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+RUN ln -s ${CONDA_DIR}/envs/${CONDA_ENV}/lib/libpython3.10.so.1.0 /usr/lib/libpython3.10.so.1.0
+
+USER ${RUNTIME_USER}
 WORKDIR /code_execution
 
 COPY entrypoint.sh /entrypoint.sh

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - cudatoolkit=11.2
   - eigen=3.4.0
+  - fastai=1.0.60
   - keras=2.11.0
   - loguru=0.6.0
   - mkl=2022.2.1


### PR DESCRIPTION
We do need to commit a new docker image since we use multiresolutionimageinterface Python package from ASAP to extract patches from WSIs for predicting, and for the predicting we use fastai which also has been added on the environment-gpu.yml.
This is a new request to meet your requirements, that add the python package installation base on original Dockerfile and environment-gpu.yml.