### PR TITLE
Remove unneeded package

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -43,7 +43,6 @@ dependencies:
   - openslide-python==1.2.0
   - timm==0.4.12
   - opencv-python-headless==4.7.0.72
-  - fastai=1.0.60
   - einops==0.6.1
   - rtree==1.0.1
   - shapely==2.0.1

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -44,7 +44,6 @@ dependencies:
   - openslide-python==1.2.0
   - timm==0.4.12
   - opencv-python-headless==4.7.0.72
-  - fastai=1.0.60
   - einops==0.6.1
   - rtree==1.0.1
   - shapely==2.0.1

--- a/runtime/tests/test_packages.py
+++ b/runtime/tests/test_packages.py
@@ -15,6 +15,7 @@ packages = [
     "sklearn",
     "tensorflow",
     "torch",
+    "multiresolutionimageinterface",  # ASAP package
 ]
 
 


### PR DESCRIPTION
#21 added an unnecessary fastai dependency which caused other version conflicts with huggingface_hub and transformers. This PR removes the unneeded library and confirms that this doesn't impact the use of ASAP.