### PR TITLE
einops does not work with conda install w pip

### DIFF
--- a/runtime/environment-cpu.yml
+++ b/runtime/environment-cpu.yml
@@ -44,7 +44,6 @@ dependencies:
   - openslide-python==1.2.0
   - timm==0.4.12
   - opencv-python-headless==4.7.0.72
-  - einops==0.6.1
   - rtree==1.0.1
   - shapely==2.0.1
   - catboost==1.2
@@ -52,3 +51,4 @@ dependencies:
   - pip:
     - staintools==2.1.2
     - spams==2.6.5.4
+    - einops==0.6.1

--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -45,7 +45,6 @@ dependencies:
   - openslide-python==1.2.0
   - timm==0.4.12
   - opencv-python-headless==4.7.0.72
-  - einops==0.6.1
   - rtree==1.0.1
   - shapely==2.0.1
   - catboost==1.2
@@ -53,3 +52,4 @@ dependencies:
   - pip:
     - staintools==2.1.2
     - spams==2.6.5.4
+    - einops==0.6.1


### PR DESCRIPTION
According to the official github page it can be installed with pip:

https://github.com/arogozhnikov/einops#Installation

I can confirm that the conda does not work in the latest gpu version:

ModuleNotFoundError: No module named 'einops'

docker pull [visiomelmelanoma.azurecr.io/visiomelmelanoma-competition:gpu-latest](http://visiomelmelanoma.azurecr.io/visiomelmelanoma-competition:gpu-latest?fbclid=IwAR1xbFeL7KzbXQwbJ8apDkPbBJgoAEQf6XzeyD9hiyr1UBAQFD4TyEiJGwY)
gpu-latest: Pulling from visiomelmelanoma-competition
Digest: sha256:d73b99fe72ab5cf50627488d99d8082f9dcac0d9a198bba46d08bb2c0a51152d
Status: Image is up to date for [visiomelmelanoma.azurecr.io/visiomelmelanoma-competition:gpu-latest](http://visiomelmelanoma.azurecr.io/visiomelmelanoma-competition:gpu-latest?fbclid=IwAR3LC5_7h1Gq_KpPQFHpZ4xdW2hnOUZLGzo_D4edoGWmvgiPZtpUn2E8tAM)
[visiomelmelanoma.azurecr.io/visiomelmelanoma-competition:gpu-latest](http://visiomelmelanoma.azurecr.io/visiomelmelanoma-competition:gpu-latest?fbclid=IwAR10PVTXd2JY7R5is5NuMOKVXDDTfUe0SwLYC8e0hOfSQrwn7agBXqi-mKE)

