### PR TITLE
Pin cudnn

### DIFF
--- a/runtime/environment-gpu.yml
+++ b/runtime/environment-gpu.yml
@@ -5,6 +5,7 @@ channels:
   - fastai
 dependencies:
   - cudatoolkit=11.2
+  - cudnn=8.4.1
   - eigen=3.4.0
   - keras=2.11.0
   - loguru=0.6.0


### PR DESCRIPTION
The update of cudnn to 8.8 from 8.4 appears to be causing the `RuntimeError: cuDNN error: CUDNN_STATUS_ARCH_MISMATCH` error