### PR TITLE
Minkowski engine compute capability

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -86,7 +86,7 @@ USER ${RUNTIME_USER}
 # ======================== MinkowskiEngine installation =============
 USER root
 ENV MAX_JOBS=2 \
-    TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX" \
+    TORCH_CUDA_ARCH_LIST="3.7" \
     TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 RUN git clone https://github.com/StanfordVL/MinkowskiEngine.git /tmp/MinkowskiEngine
 WORKDIR /tmp/MinkowskiEngine

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -86,7 +86,7 @@ USER ${RUNTIME_USER}
 # ======================== MinkowskiEngine installation =============
 USER root
 ENV MAX_JOBS=2 \
-    TORCH_CUDA_ARCH_LIST="3.7" \
+    TORCH_CUDA_ARCH_LIST="3.7+PTX" \
     TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 RUN git clone https://github.com/StanfordVL/MinkowskiEngine.git /tmp/MinkowskiEngine
 WORKDIR /tmp/MinkowskiEngine


### PR DESCRIPTION
In my initial pull request I added the environmental variable **TORCH_CUDA_ARCH_LIST**, which sets the target for the compilation of the MinkowskiEngine. 

Because the competition runtime is on a K80 GPU (compute capability **3.7**) I had to change **TORCH_CUDA_ARCH_LIST** to the appropriate value so the MinkowskiEngine will be compiled with proper support for it. 